### PR TITLE
Reinstate initial goroutine check

### DIFF
--- a/test/util.go
+++ b/test/util.go
@@ -24,9 +24,10 @@ func TimeOut(t time.Duration) *time.Timer {
 
 // CheckRoutines is used to check for leaked go-routines
 func CheckRoutines(t *testing.T) func() {
+	initial := getRoutines()
 	return func() {
 		routines := getRoutines()
-		if len(routines) > 0 {
+		if len(routines) > len(initial) {
 			t.Fatalf("Unexpected routines: \n%s", strings.Join(routines, "\n\n"))
 		}
 	}


### PR DESCRIPTION
Looking at the history of this function, originally the final count was compared against an intiail count instead of 0. should we reinstate the initial count to prevent test cross-contamination?