### PR TITLE
Repeat CheckRoutines to reduce flakiness

### DIFF
--- a/test/util.go
+++ b/test/util.go
@@ -26,10 +26,18 @@ func TimeOut(t time.Duration) *time.Timer {
 func CheckRoutines(t *testing.T) func() {
 	initial := getRoutines()
 	return func() {
-		time.Sleep(500 * time.Millisecond)
-		routines := getRoutines()
-		if len(routines) > len(initial) {
-			t.Fatalf("Unexpected routines: \n%s", strings.Join(routines, "\n\n"))
+		try := 0
+		ticker := time.NewTicker(200 * time.Millisecond)
+		defer ticker.Stop()
+		for range ticker.C {
+			routines := getRoutines()
+			if len(routines) <= len(initial) {
+				return
+			}
+			if try >= 50 {
+				t.Fatalf("Unexpected routines: \n%s", strings.Join(routines, "\n\n"))
+			}
+			try++
 		}
 	}
 }

--- a/test/util_test.go
+++ b/test/util_test.go
@@ -1,0 +1,20 @@
+package test
+
+import (
+	"testing"
+	"time"
+)
+
+func TestCheckRoutines(t *testing.T) {
+	// Limit runtime in case of deadlocks
+	lim := TimeOut(time.Second * 20)
+	defer lim.Stop()
+
+	// Check for leaking routines
+	report := CheckRoutines(t)
+	defer report()
+
+	go func() {
+		time.Sleep(1 * time.Second)
+	}()
+}


### PR DESCRIPTION
Repeat CheckRoutines to reduce flakiness while not blocking
for longer than needed. The routines are now checked every
200ms for a maximum of 10s.