### PR TITLE
Connection bridge tool

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -9,6 +9,9 @@ linters:
   disable:
     - gochecknoinits
     - gochecknoglobals
+    - goconst
+    - gocyclo
+    - dupl
 
 issues:
   exclude-use-default: false

--- a/test/bridge.go
+++ b/test/bridge.go
@@ -1,0 +1,178 @@
+package test
+
+import (
+	"fmt"
+	"net"
+	"sync"
+	"time"
+)
+
+// bridgeConn is a net.Conn that represents an endpoint of the bridge.
+type bridgeConn struct {
+	br     *Bridge
+	id     int
+	readCh chan []byte
+}
+
+// Read reads data, block until the data becomes available.
+func (conn *bridgeConn) Read(b []byte) (int, error) {
+	if data, ok := <-conn.readCh; ok {
+		n := copy(b, data)
+		return n, nil
+	}
+	return 0, fmt.Errorf("bridgeConn closed")
+}
+
+// Write writes data to the bridge.
+func (conn *bridgeConn) Write(b []byte) (int, error) {
+	n := len(b)
+	conn.br.Push(b, conn.id)
+	return n, nil
+}
+
+// Close closes the bridge (releases resources used).
+func (conn *bridgeConn) Close() error {
+	close(conn.readCh)
+	return nil
+}
+
+// LocalAddr is not used
+func (conn *bridgeConn) LocalAddr() net.Addr { return nil }
+
+// RemoteAddr is not used
+func (conn *bridgeConn) RemoteAddr() net.Addr { return nil }
+
+// SetDeadline is not used
+func (conn *bridgeConn) SetDeadline(t time.Time) error { return nil }
+
+// SetReadDeadline is not used
+func (conn *bridgeConn) SetReadDeadline(t time.Time) error { return nil }
+
+// SetWriteDeadline is not used
+func (conn *bridgeConn) SetWriteDeadline(t time.Time) error { return nil }
+
+// Bridge represents a network between the two endpoints.
+type Bridge struct {
+	mutex sync.RWMutex
+	conn0 *bridgeConn
+	conn1 *bridgeConn
+
+	queue0to1 [][]byte
+	queue1to0 [][]byte
+}
+
+func inverse(s [][]byte) error {
+	if len(s) < 2 {
+		return fmt.Errorf("inverse requires more than one item in the array")
+	}
+
+	for i, j := 0, len(s)-1; i < j; i, j = i+1, j-1 {
+		s[i], s[j] = s[j], s[i]
+	}
+	return nil
+}
+
+// drop n packets from the slice starting from offset
+func drop(s [][]byte, offset, n int) [][]byte {
+	if offset+n > len(s) {
+		n = len(s) - offset
+	}
+	return append(s[:offset], s[offset+n:]...)
+}
+
+func NewBridge() (*Bridge, net.Conn, net.Conn) {
+	br := &Bridge{
+		queue0to1: make([][]byte, 0),
+		queue1to0: make([][]byte, 0),
+	}
+
+	br.conn0 = &bridgeConn{
+		br:     br,
+		id:     0,
+		readCh: make(chan []byte),
+	}
+	br.conn1 = &bridgeConn{
+		br:     br,
+		id:     1,
+		readCh: make(chan []byte),
+	}
+
+	return br, br.conn0, br.conn1
+}
+
+func (br *Bridge) Push(d []byte, fromID int) {
+	br.mutex.Lock()
+	defer br.mutex.Unlock()
+
+	if fromID == 0 {
+		br.queue0to1 = append(br.queue0to1, d)
+	} else {
+		br.queue1to0 = append(br.queue1to0, d)
+	}
+}
+
+func (br *Bridge) Reorder(fromID int) error {
+	br.mutex.Lock()
+	defer br.mutex.Unlock()
+
+	var err error
+
+	if fromID == 0 {
+		err = inverse(br.queue0to1)
+	} else {
+		err = inverse(br.queue1to0)
+	}
+
+	return err
+}
+
+func (br *Bridge) Drop(fromID, offset, n int) {
+	br.mutex.Lock()
+	defer br.mutex.Unlock()
+
+	if fromID == 0 {
+		br.queue0to1 = drop(br.queue0to1, offset, n)
+	} else {
+		br.queue1to0 = drop(br.queue1to0, offset, n)
+	}
+}
+
+func (br *Bridge) Tick() int {
+	br.mutex.Lock()
+	defer br.mutex.Unlock()
+
+	var n int
+
+	if len(br.queue0to1) > 0 {
+		select {
+		case br.conn1.readCh <- br.queue0to1[0]:
+			n++
+			//fmt.Printf("conn1 received data (%d bytes)\n", len(br.queue0to1[0]))
+			br.queue0to1 = br.queue0to1[1:]
+		default:
+		}
+	}
+
+	if len(br.queue1to0) > 0 {
+		select {
+		case br.conn0.readCh <- br.queue1to0[0]:
+			n++
+			//fmt.Printf("conn0 received data (%d bytes)\n", len(br.queue1to0[0]))
+			br.queue1to0 = br.queue1to0[1:]
+		default:
+		}
+	}
+
+	return n
+}
+
+// Repeat tick() call until no more outstanding inflight packet
+func (br *Bridge) Process() {
+	for {
+		time.Sleep(10 * time.Millisecond)
+		n := br.Tick()
+		if n == 0 {
+			break
+		}
+	}
+}

--- a/test/bridge.go
+++ b/test/bridge.go
@@ -80,7 +80,7 @@ func drop(s [][]byte, offset, n int) [][]byte {
 	return append(s[:offset], s[offset+n:]...)
 }
 
-func NewBridge() (*Bridge, net.Conn, net.Conn) {
+func NewBridge() *Bridge {
 	br := &Bridge{
 		queue0to1: make([][]byte, 0),
 		queue1to0: make([][]byte, 0),
@@ -97,7 +97,15 @@ func NewBridge() (*Bridge, net.Conn, net.Conn) {
 		readCh: make(chan []byte),
 	}
 
-	return br, br.conn0, br.conn1
+	return br
+}
+
+func (br *Bridge) GetConn0() net.Conn {
+	return br.conn0
+}
+
+func (br *Bridge) GetConn1() net.Conn {
+	return br.conn1
 }
 
 func (br *Bridge) Push(d []byte, fromID int) {

--- a/test/bridge.go
+++ b/test/bridge.go
@@ -80,6 +80,7 @@ func drop(s [][]byte, offset, n int) [][]byte {
 	return append(s[:offset], s[offset+n:]...)
 }
 
+// NewBridge creates a new bridge with two endpoints.
 func NewBridge() *Bridge {
 	br := &Bridge{
 		queue0to1: make([][]byte, 0),
@@ -100,14 +101,17 @@ func NewBridge() *Bridge {
 	return br
 }
 
+// GetConn0 returns an endpoint of the bridge, conn0.
 func (br *Bridge) GetConn0() net.Conn {
 	return br.conn0
 }
 
+// GetConn1 returns an endpoint of the bridge, conn1.
 func (br *Bridge) GetConn1() net.Conn {
 	return br.conn1
 }
 
+// Push pushes a packet into the specified queue.
 func (br *Bridge) Push(d []byte, fromID int) {
 	br.mutex.Lock()
 	defer br.mutex.Unlock()
@@ -119,6 +123,7 @@ func (br *Bridge) Push(d []byte, fromID int) {
 	}
 }
 
+// Reorder inverses the order of packets currently in the specified queue.
 func (br *Bridge) Reorder(fromID int) error {
 	br.mutex.Lock()
 	defer br.mutex.Unlock()
@@ -134,6 +139,8 @@ func (br *Bridge) Reorder(fromID int) error {
 	return err
 }
 
+// Drop drops the specified number of packets from the given offset index
+// of the specified queue.
 func (br *Bridge) Drop(fromID, offset, n int) {
 	br.mutex.Lock()
 	defer br.mutex.Unlock()
@@ -145,6 +152,9 @@ func (br *Bridge) Drop(fromID, offset, n int) {
 	}
 }
 
+// Tick attempts to hand a packet from the queue for each directions, to readers,
+// if there are waiting on the queue. If there's no reader, it will return
+// immediately.
 func (br *Bridge) Tick() int {
 	br.mutex.Lock()
 	defer br.mutex.Unlock()
@@ -174,7 +184,7 @@ func (br *Bridge) Tick() int {
 	return n
 }
 
-// Repeat tick() call until no more outstanding inflight packet
+// Process repeats tick() calls until no more outstanding packet in the queues.
 func (br *Bridge) Process() {
 	for {
 		time.Sleep(10 * time.Millisecond)

--- a/test/bridge_test.go
+++ b/test/bridge_test.go
@@ -1,0 +1,299 @@
+package test
+
+import (
+	"testing"
+)
+
+// helper to close both conns
+func closeBridge(br *Bridge) {
+	br.conn0.Close()
+	br.conn1.Close()
+}
+
+func TestBridge(t *testing.T) {
+	var n int
+	var err error
+	buf := make([]byte, 256)
+
+	t.Run("normal", func(t *testing.T) {
+		msg := "ABC"
+		br, conn0, conn1 := NewBridge()
+		n, err = conn0.Write([]byte(msg))
+		if err != nil {
+			t.Error(err.Error())
+		}
+		if n != len(msg) {
+			t.Error("unexpected length")
+		}
+
+		go func() {
+			n, err = conn1.Read(buf)
+		}()
+
+		br.Process()
+
+		if err != nil {
+			t.Error(err.Error())
+		}
+		if n != len(msg) {
+			t.Error("unexpected length")
+		}
+		closeBridge(br)
+	})
+
+	t.Run("drop 1st packet from conn0", func(t *testing.T) {
+		msg1 := "ABC"
+		msg2 := "DEFG"
+		br, conn0, conn1 := NewBridge()
+		n, err = conn0.Write([]byte(msg1))
+		if err != nil {
+			t.Error(err.Error())
+		}
+		if n != len(msg1) {
+			t.Error("unexpected length")
+		}
+		n, err = conn0.Write([]byte(msg2))
+		if err != nil {
+			t.Error(err.Error())
+		}
+		if n != len(msg2) {
+			t.Error("unexpected length")
+		}
+
+		go func() {
+			n, err = conn1.Read(buf)
+		}()
+
+		br.Drop(0, 0, 1)
+		br.Process()
+
+		if err != nil {
+			t.Error(err.Error())
+		}
+		if n != len(msg2) {
+			t.Error("unexpected length")
+		}
+		closeBridge(br)
+	})
+
+	t.Run("drop 2nd packet from conn0", func(t *testing.T) {
+		msg1 := "ABC"
+		msg2 := "DEFG"
+		br, conn0, conn1 := NewBridge()
+		n, err = conn0.Write([]byte(msg1))
+		if err != nil {
+			t.Error(err.Error())
+		}
+		if n != len(msg1) {
+			t.Error("unexpected length")
+		}
+		n, err = conn0.Write([]byte(msg2))
+		if err != nil {
+			t.Error(err.Error())
+		}
+		if n != len(msg2) {
+			t.Error("unexpected length")
+		}
+
+		go func() {
+			n, err = conn1.Read(buf)
+		}()
+
+		br.Drop(0, 1, 1)
+		br.Process()
+
+		if err != nil {
+			t.Error(err.Error())
+		}
+		if n != len(msg1) {
+			t.Error("unexpected length")
+		}
+		closeBridge(br)
+	})
+
+	t.Run("drop 1st packet from conn1", func(t *testing.T) {
+		msg1 := "ABC"
+		msg2 := "DEFG"
+		br, conn0, conn1 := NewBridge()
+		n, err = conn1.Write([]byte(msg1))
+		if err != nil {
+			t.Error(err.Error())
+		}
+		if n != len(msg1) {
+			t.Error("unexpected length")
+		}
+		n, err = conn1.Write([]byte(msg2))
+		if err != nil {
+			t.Error(err.Error())
+		}
+		if n != len(msg2) {
+			t.Error("unexpected length")
+		}
+
+		go func() {
+			n, err = conn0.Read(buf)
+		}()
+
+		br.Drop(1, 0, 1)
+		br.Process()
+
+		if err != nil {
+			t.Error(err.Error())
+		}
+		if n != len(msg2) {
+			t.Error("unexpected length")
+		}
+		closeBridge(br)
+	})
+
+	t.Run("drop 2nd packet from conn1", func(t *testing.T) {
+		msg1 := "ABC"
+		msg2 := "DEFG"
+		br, conn0, conn1 := NewBridge()
+		n, err = conn1.Write([]byte(msg1))
+		if err != nil {
+			t.Error(err.Error())
+		}
+		if n != len(msg1) {
+			t.Error("unexpected length")
+		}
+		n, err = conn1.Write([]byte(msg2))
+		if err != nil {
+			t.Error(err.Error())
+		}
+		if n != len(msg2) {
+			t.Error("unexpected length")
+		}
+
+		go func() {
+			n, err = conn0.Read(buf)
+		}()
+
+		br.Drop(1, 1, 1)
+		br.Process()
+
+		if err != nil {
+			t.Error(err.Error())
+		}
+		if n != len(msg1) {
+			t.Error("unexpected length")
+		}
+		closeBridge(br)
+	})
+
+	t.Run("reorder packets from conn0", func(t *testing.T) {
+		msg1 := "ABC"
+		msg2 := "DEFG"
+		br, conn0, conn1 := NewBridge()
+		n, err = conn0.Write([]byte(msg1))
+		if err != nil {
+			t.Error(err.Error())
+		}
+		if n != len(msg1) {
+			t.Error("unexpected length")
+		}
+		n, err = conn0.Write([]byte(msg2))
+		if err != nil {
+			t.Error(err.Error())
+		}
+		if n != len(msg2) {
+			t.Error("unexpected length")
+		}
+
+		done := make(chan bool)
+
+		go func() {
+			n, err = conn1.Read(buf)
+			if err != nil {
+				t.Error(err.Error())
+			}
+			if n != len(msg2) {
+				t.Error("unexpected length")
+			}
+			n, err = conn1.Read(buf)
+			if err != nil {
+				t.Error(err.Error())
+			}
+			if n != len(msg1) {
+				t.Error("unexpected length")
+			}
+			done <- true
+		}()
+
+		err = br.Reorder(0)
+		if err != nil {
+			t.Error(err.Error())
+		}
+		br.Process()
+		<-done
+		closeBridge(br)
+	})
+
+	t.Run("reorder packets from conn1", func(t *testing.T) {
+		msg1 := "ABC"
+		msg2 := "DEFG"
+		br, conn0, conn1 := NewBridge()
+		n, err = conn1.Write([]byte(msg1))
+		if err != nil {
+			t.Error(err.Error())
+		}
+		if n != len(msg1) {
+			t.Error("unexpected length")
+		}
+		n, err = conn1.Write([]byte(msg2))
+		if err != nil {
+			t.Error(err.Error())
+		}
+		if n != len(msg2) {
+			t.Error("unexpected length")
+		}
+
+		done := make(chan bool)
+
+		go func() {
+			n, err = conn0.Read(buf)
+			if err != nil {
+				t.Error(err.Error())
+			}
+			if n != len(msg2) {
+				t.Error("unexpected length")
+			}
+			n, err = conn0.Read(buf)
+			if err != nil {
+				t.Error(err.Error())
+			}
+			if n != len(msg1) {
+				t.Error("unexpected length")
+			}
+			done <- true
+		}()
+
+		err = br.Reorder(1)
+		if err != nil {
+			t.Error(err.Error())
+		}
+		br.Process()
+		<-done
+		closeBridge(br)
+	})
+
+	t.Run("inverse error", func(t *testing.T) {
+		q := [][]byte{}
+		q = append(q, []byte("ABC"))
+		err := inverse(q)
+		if err == nil {
+			t.Error("inverse should fail if less than 2 pkts")
+		}
+	})
+
+	t.Run("read closed conn", func(t *testing.T) {
+		_, conn0, conn1 := NewBridge()
+		conn0.Close()
+		conn1.Close()
+
+		_, err = conn0.Read(buf)
+		if err == nil {
+			t.Error("read should fail as conn is closed")
+		}
+	})
+}

--- a/test/bridge_test.go
+++ b/test/bridge_test.go
@@ -17,7 +17,10 @@ func TestBridge(t *testing.T) {
 
 	t.Run("normal", func(t *testing.T) {
 		msg := "ABC"
-		br, conn0, conn1 := NewBridge()
+		br := NewBridge()
+		conn0 := br.GetConn0()
+		conn1 := br.GetConn1()
+
 		n, err = conn0.Write([]byte(msg))
 		if err != nil {
 			t.Error(err.Error())
@@ -44,7 +47,10 @@ func TestBridge(t *testing.T) {
 	t.Run("drop 1st packet from conn0", func(t *testing.T) {
 		msg1 := "ABC"
 		msg2 := "DEFG"
-		br, conn0, conn1 := NewBridge()
+		br := NewBridge()
+		conn0 := br.GetConn0()
+		conn1 := br.GetConn1()
+
 		n, err = conn0.Write([]byte(msg1))
 		if err != nil {
 			t.Error(err.Error())
@@ -79,7 +85,10 @@ func TestBridge(t *testing.T) {
 	t.Run("drop 2nd packet from conn0", func(t *testing.T) {
 		msg1 := "ABC"
 		msg2 := "DEFG"
-		br, conn0, conn1 := NewBridge()
+		br := NewBridge()
+		conn0 := br.GetConn0()
+		conn1 := br.GetConn1()
+
 		n, err = conn0.Write([]byte(msg1))
 		if err != nil {
 			t.Error(err.Error())
@@ -114,7 +123,10 @@ func TestBridge(t *testing.T) {
 	t.Run("drop 1st packet from conn1", func(t *testing.T) {
 		msg1 := "ABC"
 		msg2 := "DEFG"
-		br, conn0, conn1 := NewBridge()
+		br := NewBridge()
+		conn0 := br.GetConn0()
+		conn1 := br.GetConn1()
+
 		n, err = conn1.Write([]byte(msg1))
 		if err != nil {
 			t.Error(err.Error())
@@ -149,7 +161,10 @@ func TestBridge(t *testing.T) {
 	t.Run("drop 2nd packet from conn1", func(t *testing.T) {
 		msg1 := "ABC"
 		msg2 := "DEFG"
-		br, conn0, conn1 := NewBridge()
+		br := NewBridge()
+		conn0 := br.GetConn0()
+		conn1 := br.GetConn1()
+
 		n, err = conn1.Write([]byte(msg1))
 		if err != nil {
 			t.Error(err.Error())
@@ -184,7 +199,10 @@ func TestBridge(t *testing.T) {
 	t.Run("reorder packets from conn0", func(t *testing.T) {
 		msg1 := "ABC"
 		msg2 := "DEFG"
-		br, conn0, conn1 := NewBridge()
+		br := NewBridge()
+		conn0 := br.GetConn0()
+		conn1 := br.GetConn1()
+
 		n, err = conn0.Write([]byte(msg1))
 		if err != nil {
 			t.Error(err.Error())
@@ -232,7 +250,10 @@ func TestBridge(t *testing.T) {
 	t.Run("reorder packets from conn1", func(t *testing.T) {
 		msg1 := "ABC"
 		msg2 := "DEFG"
-		br, conn0, conn1 := NewBridge()
+		br := NewBridge()
+		conn0 := br.GetConn0()
+		conn1 := br.GetConn1()
+
 		n, err = conn1.Write([]byte(msg1))
 		if err != nil {
 			t.Error(err.Error())
@@ -287,7 +308,10 @@ func TestBridge(t *testing.T) {
 	})
 
 	t.Run("read closed conn", func(t *testing.T) {
-		_, conn0, conn1 := NewBridge()
+		br := NewBridge()
+		conn0 := br.GetConn0()
+		conn1 := br.GetConn1()
+
 		conn0.Close()
 		conn1.Close()
 

--- a/test/bridge_test.go
+++ b/test/bridge_test.go
@@ -5,9 +5,13 @@ import (
 )
 
 // helper to close both conns
-func closeBridge(br *Bridge) {
-	br.conn0.Close()
-	br.conn1.Close()
+func closeBridge(br *Bridge) error {
+	if err := br.conn0.Close(); err != nil {
+		return err
+
+	}
+
+	return br.conn1.Close()
 }
 
 type AsyncResult struct {
@@ -16,9 +20,6 @@ type AsyncResult struct {
 }
 
 func TestBridge(t *testing.T) {
-	var n int
-	var err error
-
 	buf := make([]byte, 256)
 
 	t.Run("normal", func(t *testing.T) {
@@ -28,7 +29,7 @@ func TestBridge(t *testing.T) {
 		conn0 := br.GetConn0()
 		conn1 := br.GetConn1()
 
-		n, err = conn0.Write([]byte(msg))
+		n, err := conn0.Write([]byte(msg))
 		if err != nil {
 			t.Error(err.Error())
 		}
@@ -37,8 +38,8 @@ func TestBridge(t *testing.T) {
 		}
 
 		go func() {
-			n, err := conn1.Read(buf)
-			readRes <- AsyncResult{n: n, err: err}
+			nInner, errInner := conn1.Read(buf)
+			readRes <- AsyncResult{n: nInner, err: errInner}
 		}()
 
 		br.Process()
@@ -50,7 +51,9 @@ func TestBridge(t *testing.T) {
 		if ar.n != len(msg) {
 			t.Error("unexpected length")
 		}
-		closeBridge(br)
+		if err = closeBridge(br); err != nil {
+			t.Error(err)
+		}
 	})
 
 	t.Run("drop 1st packet from conn0", func(t *testing.T) {
@@ -61,7 +64,7 @@ func TestBridge(t *testing.T) {
 		conn0 := br.GetConn0()
 		conn1 := br.GetConn1()
 
-		n, err = conn0.Write([]byte(msg1))
+		n, err := conn0.Write([]byte(msg1))
 		if err != nil {
 			t.Error(err.Error())
 		}
@@ -77,8 +80,8 @@ func TestBridge(t *testing.T) {
 		}
 
 		go func() {
-			n, err := conn1.Read(buf)
-			readRes <- AsyncResult{n: n, err: err}
+			nInner, errInner := conn1.Read(buf)
+			readRes <- AsyncResult{n: nInner, err: errInner}
 		}()
 
 		br.Drop(0, 0, 1)
@@ -91,7 +94,9 @@ func TestBridge(t *testing.T) {
 		if ar.n != len(msg2) {
 			t.Error("unexpected length")
 		}
-		closeBridge(br)
+		if err = closeBridge(br); err != nil {
+			t.Error(err)
+		}
 	})
 
 	t.Run("drop 2nd packet from conn0", func(t *testing.T) {
@@ -102,7 +107,7 @@ func TestBridge(t *testing.T) {
 		conn0 := br.GetConn0()
 		conn1 := br.GetConn1()
 
-		n, err = conn0.Write([]byte(msg1))
+		n, err := conn0.Write([]byte(msg1))
 		if err != nil {
 			t.Error(err.Error())
 		}
@@ -118,8 +123,8 @@ func TestBridge(t *testing.T) {
 		}
 
 		go func() {
-			n, err := conn1.Read(buf)
-			readRes <- AsyncResult{n: n, err: err}
+			nInner, errInner := conn1.Read(buf)
+			readRes <- AsyncResult{n: nInner, err: errInner}
 		}()
 
 		br.Drop(0, 1, 1)
@@ -132,7 +137,9 @@ func TestBridge(t *testing.T) {
 		if ar.n != len(msg1) {
 			t.Error("unexpected length")
 		}
-		closeBridge(br)
+		if err = closeBridge(br); err != nil {
+			t.Error(err)
+		}
 	})
 
 	t.Run("drop 1st packet from conn1", func(t *testing.T) {
@@ -143,7 +150,7 @@ func TestBridge(t *testing.T) {
 		conn0 := br.GetConn0()
 		conn1 := br.GetConn1()
 
-		n, err = conn1.Write([]byte(msg1))
+		n, err := conn1.Write([]byte(msg1))
 		if err != nil {
 			t.Error(err.Error())
 		}
@@ -159,8 +166,8 @@ func TestBridge(t *testing.T) {
 		}
 
 		go func() {
-			n, err := conn0.Read(buf)
-			readRes <- AsyncResult{n: n, err: err}
+			nInner, errInner := conn0.Read(buf)
+			readRes <- AsyncResult{n: nInner, err: errInner}
 		}()
 
 		br.Drop(1, 0, 1)
@@ -173,7 +180,9 @@ func TestBridge(t *testing.T) {
 		if ar.n != len(msg2) {
 			t.Error("unexpected length")
 		}
-		closeBridge(br)
+		if err = closeBridge(br); err != nil {
+			t.Error(err)
+		}
 	})
 
 	t.Run("drop 2nd packet from conn1", func(t *testing.T) {
@@ -184,7 +193,7 @@ func TestBridge(t *testing.T) {
 		conn0 := br.GetConn0()
 		conn1 := br.GetConn1()
 
-		n, err = conn1.Write([]byte(msg1))
+		n, err := conn1.Write([]byte(msg1))
 		if err != nil {
 			t.Error(err.Error())
 		}
@@ -200,8 +209,8 @@ func TestBridge(t *testing.T) {
 		}
 
 		go func() {
-			n, err := conn0.Read(buf)
-			readRes <- AsyncResult{n: n, err: err}
+			nInner, errInner := conn0.Read(buf)
+			readRes <- AsyncResult{n: nInner, err: errInner}
 		}()
 
 		br.Drop(1, 1, 1)
@@ -214,7 +223,9 @@ func TestBridge(t *testing.T) {
 		if ar.n != len(msg1) {
 			t.Error("unexpected length")
 		}
-		closeBridge(br)
+		if err = closeBridge(br); err != nil {
+			t.Error(err)
+		}
 	})
 
 	t.Run("reorder packets from conn0", func(t *testing.T) {
@@ -224,7 +235,7 @@ func TestBridge(t *testing.T) {
 		conn0 := br.GetConn0()
 		conn1 := br.GetConn1()
 
-		n, err = conn0.Write([]byte(msg1))
+		n, err := conn0.Write([]byte(msg1))
 		if err != nil {
 			t.Error(err.Error())
 		}
@@ -242,18 +253,18 @@ func TestBridge(t *testing.T) {
 		done := make(chan bool)
 
 		go func() {
-			n, err := conn1.Read(buf)
-			if err != nil {
-				t.Error(err.Error())
+			nInner, errInner := conn1.Read(buf)
+			if errInner != nil {
+				t.Error(errInner.Error())
 			}
-			if n != len(msg2) {
+			if nInner != len(msg2) {
 				t.Error("unexpected length")
 			}
-			n, err = conn1.Read(buf)
-			if err != nil {
-				t.Error(err.Error())
+			nInner, errInner = conn1.Read(buf)
+			if errInner != nil {
+				t.Error(errInner.Error())
 			}
-			if n != len(msg1) {
+			if nInner != len(msg1) {
 				t.Error("unexpected length")
 			}
 			done <- true
@@ -265,7 +276,9 @@ func TestBridge(t *testing.T) {
 		}
 		br.Process()
 		<-done
-		closeBridge(br)
+		if err = closeBridge(br); err != nil {
+			t.Error(err)
+		}
 	})
 
 	t.Run("reorder packets from conn1", func(t *testing.T) {
@@ -275,7 +288,7 @@ func TestBridge(t *testing.T) {
 		conn0 := br.GetConn0()
 		conn1 := br.GetConn1()
 
-		n, err = conn1.Write([]byte(msg1))
+		n, err := conn1.Write([]byte(msg1))
 		if err != nil {
 			t.Error(err.Error())
 		}
@@ -293,18 +306,18 @@ func TestBridge(t *testing.T) {
 		done := make(chan bool)
 
 		go func() {
-			n, err := conn0.Read(buf)
-			if err != nil {
-				t.Error(err.Error())
+			nInner, errInner := conn0.Read(buf)
+			if errInner != nil {
+				t.Error(errInner.Error())
 			}
-			if n != len(msg2) {
+			if nInner != len(msg2) {
 				t.Error("unexpected length")
 			}
-			n, err = conn0.Read(buf)
-			if err != nil {
-				t.Error(err.Error())
+			nInner, errInner = conn0.Read(buf)
+			if errInner != nil {
+				t.Error(errInner.Error())
 			}
-			if n != len(msg1) {
+			if nInner != len(msg1) {
 				t.Error("unexpected length")
 			}
 			done <- true
@@ -316,14 +329,15 @@ func TestBridge(t *testing.T) {
 		}
 		br.Process()
 		<-done
-		closeBridge(br)
+		if err = closeBridge(br); err != nil {
+			t.Error(err)
+		}
 	})
 
 	t.Run("inverse error", func(t *testing.T) {
 		q := [][]byte{}
 		q = append(q, []byte("ABC"))
-		err := inverse(q)
-		if err == nil {
+		if err := inverse(q); err == nil {
 			t.Error("inverse should fail if less than 2 pkts")
 		}
 	})
@@ -333,10 +347,14 @@ func TestBridge(t *testing.T) {
 		conn0 := br.GetConn0()
 		conn1 := br.GetConn1()
 
-		conn0.Close()
-		conn1.Close()
+		if err := conn0.Close(); err != nil {
+			t.Error(err)
+		}
+		if err := conn1.Close(); err != nil {
+			t.Error(err)
+		}
 
-		_, err = conn0.Read(buf)
+		_, err := conn0.Read(buf)
 		if err == nil {
 			t.Error("read should fail as conn is closed")
 		}


### PR DESCRIPTION
Added connection bridge test used by new sctp and datachannel tests. Typical usage is to connect two SCTP endpoints with this bridge. The bridge allows you to drop, reorder packets as needed.

This relates to pions/webrtc#334