### PR TITLE
Conn and PacketConn

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ Check out the **[contributing wiki](https://github.com/pions/webrtc/wiki/Contrib
 * [Yutaka Takeda](https://github.com/enobufs) *Bridge, simulates loss and out of order packets*
 * [Sean DuBois](https://github.com/Sean-Der) - *Testing Infra*
 * [Woodrow Douglass](https://github.com/wdouglass) *Fix test flakiness*
+* [Luke Curley](https://github.com/kixelated) *Batched packet support*
 
 ### License
 MIT License - see [LICENSE](LICENSE) for full text

--- a/conn.go
+++ b/conn.go
@@ -1,0 +1,33 @@
+package transport
+
+import (
+	"net"
+)
+
+// Conn is an extension of net.Conn with batched support
+type Conn interface {
+	net.Conn
+
+	// ReadBatch takes a slice of Messages, reading them in bulk if supported.
+	// Returns the number of messages read, which may be less than the full slice.
+	// Each message will have Buffer and Size populated.
+	ReadBatch(ms []Message) (n int, err error)
+
+	// WriteBatch takes a slice of Messages, writing them in bulk if supported.
+	// Returns the number of messages written, which may be less than the full slice.
+	// Each message will have Size populated with the number of bytes written.
+	WriteBatch(ms []Message) (n int, err error)
+}
+
+// NewConn creates a Conn given a net.Conn
+// This is a wrapper, added stubs for batched support when needed.
+func NewConn(conn net.Conn) (c Conn) {
+	switch ct := conn.(type) {
+	case Conn:
+		// Don't wrap if it already implements the interface.
+		return ct
+	default:
+		// Otherwise use a wrapper that translates the batch calls into single reads/writes
+		return newMessageSingler(conn)
+	}
+}

--- a/conn_test.go
+++ b/conn_test.go
@@ -1,0 +1,136 @@
+package transport
+
+import (
+	"bytes"
+	"io"
+	"net"
+	"sync"
+	"testing"
+)
+
+// Test writing and reading from a wrapped connection with the batch methods.
+func TestNewConn(t *testing.T) {
+	r, w := net.Pipe()
+
+	// NOTE: Both of these will use messageSingler.
+	rc := NewConn(r)
+	wc := NewConn(w)
+
+	wg := sync.WaitGroup{}
+	wg.Add(2)
+
+	messageCount := 10
+	messageContents := func(n int) (message []byte) {
+		// This function can produce anything, so long as it's <= 10 bytes.
+		for i := 0; i < n+1; i++ {
+			message = append(message, byte(n+i))
+		}
+
+		return message
+	}
+
+	go func() {
+		defer wg.Done()
+
+		count := 0
+
+		for {
+			// Read at most three messages at a time.
+			ms := make([]Message, 3)
+
+			for i := range ms {
+				// Read at most 10 bytes at a time.
+				ms[i].Buffer = make([]byte, 10)
+			}
+
+			n, err := rc.ReadBatch(ms)
+			if err == io.EOF {
+				break
+			} else if err != nil {
+				t.Error(err)
+			}
+
+			if n <= 0 {
+				t.Error("number read in non-positive")
+			}
+
+			for i := 0; i < n; i++ {
+				m := ms[i]
+				expected := messageContents(count + i)
+
+				if len(expected) != m.Size {
+					t.Error("wrong message size")
+				}
+
+				if !bytes.Equal(expected, m.Buffer[:m.Size]) {
+					t.Error("wrong message contents")
+				}
+			}
+
+			count += n
+		}
+
+		if count != messageCount {
+			t.Error("wrong number of messages received")
+		}
+
+		err := rc.Close()
+		if err != nil {
+			t.Error(err)
+		}
+	}()
+
+	go func() {
+		defer wg.Done()
+
+		count := 0
+
+		for count < messageCount {
+			// Write at most four messages at a time.
+			num := 4
+
+			// Send fewer than four messages if we go over.
+			if num > messageCount-count {
+				num = messageCount - count
+			}
+
+			ms := make([]Message, num)
+
+			// Populate our messages with the contents.
+			for i := range ms {
+				ms[i].Buffer = messageContents(count + i)
+			}
+
+			// Try to write the batch of messages.
+			n, err := wc.WriteBatch(ms)
+			if err != nil {
+				t.Error(err)
+			}
+
+			if n <= 0 {
+				t.Error("number written in non-positive")
+			}
+
+			for i := 0; i < n; i++ {
+				m := ms[i]
+
+				if m.Size != len(messageContents(count+i)) {
+					t.Error("wrong number of written bytes")
+				}
+			}
+
+			count += n
+		}
+
+		if count != messageCount {
+			t.Error("wrong number of messages sent")
+		}
+
+		err := wc.Close()
+		if err != nil {
+			t.Error(err)
+		}
+	}()
+
+	wg.Wait()
+}

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/pions/transport
+
+go 1.12

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,5 @@
 module github.com/pions/transport
 
 go 1.12
+
+require golang.org/x/net v0.0.0-20190301231341-16b79f2e4e95

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+golang.org/x/net v0.0.0-20190301231341-16b79f2e4e95 h1:fY7Dsw114eJN4boqzVSbpVHO6rTdhq6/GnXeu+PKnzU=
+golang.org/x/net v0.0.0-20190301231341-16b79f2e4e95/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=

--- a/message.go
+++ b/message.go
@@ -1,0 +1,7 @@
+package transport
+
+// Message is a buffer and size sent/received by a connection.
+type Message struct {
+	Buffer []byte
+	Size   int
+}

--- a/message_singler.go
+++ b/message_singler.go
@@ -17,6 +17,10 @@ func (msr *messageSingler) ReadBatch(ms []Message) (n int, err error) {
 		return 0, nil
 	}
 
+	// We can only read a single message with blocking IO.
+	// It may be worth implementing non-blocking IO to slightly improve performance.
+
+	// The pointer is required to modify the slice value.
 	m := &ms[0]
 
 	m.Size, err = msr.Read(m.Buffer)
@@ -28,16 +32,19 @@ func (msr *messageSingler) ReadBatch(ms []Message) (n int, err error) {
 }
 
 func (msr *messageSingler) WriteBatch(ms []Message) (n int, err error) {
-	if len(ms) == 0 {
-		return 0, nil
+	// We could just write a single message, but loop for better performance.
+	// This will avoid function overhead and having the caller potentially reconstruct the Message slice.
+
+	for i := range ms {
+		// The pointer is required to modify the slice value.
+		m := &ms[i]
+
+		m.Size, err = msr.Write(m.Buffer)
+		if err != nil {
+			// Return the number of successful messages on error.
+			return i, err
+		}
 	}
 
-	m := &ms[0]
-
-	m.Size, err = msr.Write(m.Buffer)
-	if err != nil {
-		return 0, err
-	}
-
-	return 1, nil
+	return len(ms), nil
 }

--- a/message_singler.go
+++ b/message_singler.go
@@ -1,0 +1,43 @@
+package transport
+
+import (
+	"net"
+)
+
+type messageSingler struct {
+	net.Conn
+}
+
+func newMessageSingler(conn net.Conn) (ms *messageSingler) {
+	return &messageSingler{conn}
+}
+
+func (msr *messageSingler) ReadBatch(ms []Message) (n int, err error) {
+	if len(ms) == 0 {
+		return 0, nil
+	}
+
+	m := &ms[0]
+
+	m.Size, err = msr.Read(m.Buffer)
+	if err != nil {
+		return 0, err
+	}
+
+	return 1, nil
+}
+
+func (msr *messageSingler) WriteBatch(ms []Message) (n int, err error) {
+	if len(ms) == 0 {
+		return 0, nil
+	}
+
+	m := &ms[0]
+
+	m.Size, err = msr.Write(m.Buffer)
+	if err != nil {
+		return 0, err
+	}
+
+	return 1, nil
+}

--- a/packet.go
+++ b/packet.go
@@ -1,0 +1,11 @@
+package transport
+
+import (
+	"net"
+)
+
+// Packet is a message also containing an address.
+type Packet struct {
+	Addr net.Addr
+	Message
+}

--- a/packet_batcher.go
+++ b/packet_batcher.go
@@ -1,0 +1,58 @@
+package transport
+
+import (
+	"net"
+
+	"golang.org/x/net/ipv4"
+)
+
+type packetBatcher struct {
+	net.PacketConn
+
+	ipv4 *ipv4.PacketConn
+}
+
+func newPacketBatcher(conn net.PacketConn) (pb *packetBatcher) {
+	return &packetBatcher{
+		PacketConn: conn,
+		ipv4:       ipv4.NewPacketConn(conn),
+	}
+}
+
+func (pb *packetBatcher) ReadBatch(ps []Packet) (n int, err error) {
+	messages := make([]ipv4.Message, len(ps))
+
+	for i, p := range ps {
+		messages[i] = ipv4.Message{
+			Addr:    p.Addr,
+			Buffers: [][]byte{p.Buffer},
+		}
+	}
+
+	n, err = pb.ipv4.ReadBatch(messages, 0)
+
+	for i := 0; i < n; i++ {
+		ps[i].Size = messages[i].N
+	}
+
+	return n, err
+}
+
+func (pb *packetBatcher) WriteBatch(ps []Packet) (n int, err error) {
+	messages := make([]ipv4.Message, len(ps))
+
+	for i, p := range ps {
+		messages[i] = ipv4.Message{
+			Addr:    p.Addr,
+			Buffers: [][]byte{p.Buffer},
+		}
+	}
+
+	n, err = pb.ipv4.WriteBatch(messages, 0)
+
+	for i := 0; i < n; i++ {
+		ps[i].Size = messages[i].N
+	}
+
+	return n, err
+}

--- a/packet_conn.go
+++ b/packet_conn.go
@@ -1,0 +1,30 @@
+package transport
+
+import (
+	"net"
+)
+
+// PacketConn is an extension of net.PacketConn with batched support
+type PacketConn interface {
+	net.PacketConn
+
+	ReadBatch(ps []Packet) (n int, err error)
+	WriteBatch(ps []Packet) (n int, err error)
+}
+
+// NewPacketConn creates a PacketConn given a net.PacketConn
+// This is a wrapper, added batched support when a net.IPConn or net.UDPConn is provided.
+func NewPacketConn(conn net.PacketConn) (pc PacketConn) {
+	switch ct := conn.(type) {
+	case PacketConn:
+		// Don't wrap if it already implements the interface.
+		return ct
+	case *net.IPConn, *net.UDPConn:
+		// Wrap the connection with a batcher that uses sendmmsg.
+		// We have to check for raw IPConn and UDPConn otherwise it will error.
+		return newPacketBatcher(conn)
+	default:
+		// Otherwise use a wrapper that translates the batch calls into single reads/writes
+		return newPacketSingler(conn)
+	}
+}

--- a/packet_singler.go
+++ b/packet_singler.go
@@ -1,0 +1,46 @@
+package transport
+
+import (
+	"net"
+)
+
+type packetSingler struct {
+	net.PacketConn
+}
+
+func newPacketSingler(conn net.PacketConn) (ps *packetSingler) {
+	return &packetSingler{conn}
+}
+
+func (psr *packetSingler) ReadBatch(ps []Packet) (n int, err error) {
+	if len(ps) == 0 {
+		return 0, nil
+	}
+
+	p := &ps[0]
+
+	size, addr, err := psr.ReadFrom(p.Buffer)
+	if err != nil {
+		return 0, err
+	}
+
+	p.Addr = addr
+	p.Size = size
+
+	return 1, nil
+}
+
+func (psr *packetSingler) WriteBatch(ps []Packet) (n int, err error) {
+	if len(ps) == 0 {
+		return 0, nil
+	}
+
+	p := &ps[0]
+
+	p.Size, err = psr.WriteTo(p.Buffer, p.Addr)
+	if err != nil {
+		return 0, err
+	}
+
+	return 1, nil
+}


### PR DESCRIPTION
These are wrappers around net.Conn and net.PacketConn respectively, implementing batched reads/writes when possible.

My only potential change would be to better differentiate the `WriteBatch` methods between both. Perhaps: `ReadPackets`/`WritePackets` and `ReadMessages`/`WriteMessages`