### PR TITLE
Add packetio interface for network buffering

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,5 @@
 module github.com/pions/transport
 
 go 1.12
+
+require github.com/stretchr/testify v1.3.0

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,7 @@
+github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.3.0 h1:TivCn/peBQ7UY8ooIcPgZFpTNSz0Q2U6UrFlUfqbe0Q=
+github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=

--- a/packetio/buffer.go
+++ b/packetio/buffer.go
@@ -1,0 +1,195 @@
+package packetio
+
+import (
+	"errors"
+	"io"
+	"sync"
+)
+
+// ErrFull is returned when the buffer has hit the configured limits.
+var ErrFull = errors.New("full buffer")
+
+// Buffer allows writing packets to an intermediate buffer, which can then be read form.
+// This is verify similar to bytes.Buffer but avoids combining multiple writes into a single read.
+type Buffer struct {
+	mutex   sync.Mutex
+	packets [][]byte
+
+	notify chan struct{}
+	subs   bool
+	closed bool
+
+	// The number of buffered packets in bytes.
+	size int
+
+	// The limit on Write in packet count and total size.
+	limitCount int
+	limitSize  int
+}
+
+// NewBuffer creates a new Buffer object.
+func NewBuffer() *Buffer {
+	return &Buffer{
+		notify: make(chan struct{}),
+	}
+}
+
+// Write appends a copy of the packet data to the buffer.
+// If any defined limits are hit, returns ErrFull.
+func (b *Buffer) Write(packet []byte) (n int, err error) {
+	// Copy the packet before adding it.
+	packet = append([]byte{}, packet...)
+
+	b.mutex.Lock()
+
+	// Make sure we're not closed.
+	if b.closed {
+		b.mutex.Unlock()
+		return 0, io.ErrClosedPipe
+	}
+
+	// Check if there is available capacity
+	if b.limitCount != 0 && len(b.packets)+1 > b.limitCount {
+		b.mutex.Unlock()
+		return 0, ErrFull
+	}
+
+	// Check if there is available capacity
+	if b.limitSize != 0 && b.size+len(packet) > b.limitSize {
+		b.mutex.Unlock()
+		return 0, ErrFull
+	}
+
+	var notify chan struct{}
+
+	// Decide if we need to wake up any readers.
+	if b.subs {
+		// If so, close the notify channel and make a new one.
+		// This effectively behaves like a broadcast, waking up any blocked goroutines.
+		// We close after we release the lock to reduce contention.
+		notify = b.notify
+		b.notify = make(chan struct{})
+
+		// Reset the subs marker.
+		b.subs = false
+	}
+
+	// Add the packet to the queue.
+	b.packets = append(b.packets, packet)
+	b.size += len(packet)
+	b.mutex.Unlock()
+
+	// Actually close the notify channel down here.
+	if notify != nil {
+		close(notify)
+	}
+
+	return len(packet), nil
+}
+
+// Read populates the given byte slice, returning the number of bytes read.
+// Blocks until data is available or the buffer is closed.
+// Returns io.ErrShortBuffer is the packet is too small to copy the Write.
+// Returns io.EOF if the buffer is closed.
+func (b *Buffer) Read(packet []byte) (n int, err error) {
+	for {
+		b.mutex.Lock()
+
+		// See if there are any packets in the queue.
+		if len(b.packets) > 0 {
+			first := b.packets[0]
+
+			// This is a packet-based reader/writer so we can't truncate.
+			if len(first) > len(packet) {
+				b.mutex.Unlock()
+				return 0, io.ErrShortBuffer
+			}
+
+			// Remove our packet and continue.
+			b.packets = b.packets[1:]
+			b.size -= len(first)
+
+			b.mutex.Unlock()
+
+			// Actually transfer the data.
+			n := copy(packet, first)
+			return n, nil
+		}
+
+		// Make sure the reader isn't actually closed.
+		// This is done after checking packets to fully read the buffer.
+		if b.closed {
+			b.mutex.Unlock()
+			return 0, io.EOF
+		}
+
+		// Get the current notify channel.
+		// This will be closed when there is new data available, waking us up.
+		notify := b.notify
+
+		// Set the subs marker, telling the writer we're waiting.
+		b.subs = true
+		b.mutex.Unlock()
+
+		// Wake for the broadcast.
+		<-notify
+	}
+}
+
+// Close will unblock any readers and prevent future writes.
+// Data in the buffer can still be read, returning io.EOF when fully depleted.
+func (b *Buffer) Close() (err error) {
+	// note: We don't use defer so we can close the notify channel after unlocking.
+	// This will unblock goroutines that can grab the lock immediately, instead of blocking again.
+	b.mutex.Lock()
+
+	if b.closed {
+		b.mutex.Unlock()
+		return nil
+	}
+
+	notify := b.notify
+
+	b.closed = true
+	b.mutex.Unlock()
+
+	close(notify)
+
+	return nil
+}
+
+// Count returns the number of packets in the buffer.
+func (b *Buffer) Count() int {
+	b.mutex.Lock()
+	defer b.mutex.Unlock()
+
+	return len(b.packets)
+}
+
+// SetLimitCount controls the maximum number of packets that can be buffered.
+// Causes Write to return ErrFull when this limit is reached.
+// A zero value will disable this limit.
+func (b *Buffer) SetLimitCount(limit int) {
+	b.mutex.Lock()
+	defer b.mutex.Unlock()
+
+	b.limitCount = limit
+}
+
+// Size returns the total byte size of packets in the buffer.
+func (b *Buffer) Size() int {
+	b.mutex.Lock()
+	defer b.mutex.Unlock()
+
+	return b.size
+}
+
+// SetLimitSize controls the maximum number of bytes that can be buffered.
+// Causes Write to return ErrFull when this limit is reached.
+// A zero value will disable this limit.
+func (b *Buffer) SetLimitSize(limit int) {
+	b.mutex.Lock()
+	defer b.mutex.Unlock()
+
+	b.limitSize = limit
+}

--- a/packetio/buffer_test.go
+++ b/packetio/buffer_test.go
@@ -1,0 +1,324 @@
+package packetio
+
+import (
+	"io"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestBuffer(t *testing.T) {
+	assert := assert.New(t)
+
+	buffer := NewBuffer()
+	packet := make([]byte, 4)
+
+	// Write once
+	n, err := buffer.Write([]byte{0, 1})
+	assert.NoError(err)
+	assert.Equal(2, n)
+
+	// Read once
+	n, err = buffer.Read(packet)
+	assert.NoError(err)
+	assert.Equal(2, n)
+	assert.Equal([]byte{0, 1}, packet[:n])
+
+	// Write twice
+	n, err = buffer.Write([]byte{2, 3, 4})
+	assert.NoError(err)
+	assert.Equal(3, n)
+
+	n, err = buffer.Write([]byte{5, 6, 7})
+	assert.NoError(err)
+	assert.Equal(3, n)
+
+	// Read twice
+	n, err = buffer.Read(packet)
+	assert.NoError(err)
+	assert.Equal(3, n)
+	assert.Equal([]byte{2, 3, 4}, packet[:n])
+
+	n, err = buffer.Read(packet)
+	assert.NoError(err)
+	assert.Equal(3, n)
+	assert.Equal([]byte{5, 6, 7}, packet[:n])
+
+	// Write once prior to close.
+	_, err = buffer.Write([]byte{3})
+	assert.NoError(err)
+
+	// Close
+	err = buffer.Close()
+	assert.NoError(err)
+
+	// Future writes will error
+	_, err = buffer.Write([]byte{4})
+	assert.Error(err)
+
+	// But we can read the remaining data.
+	n, err = buffer.Read(packet)
+	assert.NoError(err)
+	assert.Equal(1, n)
+	assert.Equal([]byte{3}, packet[:n])
+
+	// Until EOF
+	_, err = buffer.Read(packet)
+	assert.Equal(io.EOF, err)
+}
+
+func TestBufferAsync(t *testing.T) {
+	assert := assert.New(t)
+
+	buffer := NewBuffer()
+
+	// Start up a goroutine to start a blocking read.
+	done := make(chan struct{})
+	go func() {
+		packet := make([]byte, 4)
+
+		n, err := buffer.Read(packet)
+		assert.NoError(err)
+		assert.Equal(2, n)
+		assert.Equal([]byte{0, 1}, packet[:n])
+
+		_, err = buffer.Read(packet)
+		assert.Equal(io.EOF, err)
+
+		close(done)
+	}()
+
+	// Wait for the reader to start reading.
+	time.Sleep(time.Millisecond)
+
+	// Write once
+	n, err := buffer.Write([]byte{0, 1})
+	assert.NoError(err)
+	assert.Equal(2, n)
+
+	// Wait for the reader to start reading again.
+	time.Sleep(time.Millisecond)
+
+	// Close will unblock the reader.
+	err = buffer.Close()
+	assert.NoError(err)
+
+	<-done
+}
+
+func TestBufferLimitCount(t *testing.T) {
+	assert := assert.New(t)
+
+	buffer := NewBuffer()
+	buffer.SetLimitCount(2)
+
+	assert.Equal(0, buffer.Count())
+
+	// Write twice
+	n, err := buffer.Write([]byte{0, 1})
+	assert.NoError(err)
+	assert.Equal(2, n)
+	assert.Equal(1, buffer.Count())
+
+	n, err = buffer.Write([]byte{2, 3})
+	assert.NoError(err)
+	assert.Equal(2, n)
+	assert.Equal(2, buffer.Count())
+
+	// Over capacity
+	_, err = buffer.Write([]byte{4, 5})
+	assert.Equal(ErrFull, err)
+	assert.Equal(2, buffer.Count())
+
+	// Read once
+	packet := make([]byte, 4)
+	n, err = buffer.Read(packet)
+	assert.NoError(err)
+	assert.Equal(2, n)
+	assert.Equal([]byte{0, 1}, packet[:n])
+	assert.Equal(1, buffer.Count())
+
+	// Write once
+	n, err = buffer.Write([]byte{6, 7})
+	assert.NoError(err)
+	assert.Equal(2, n)
+	assert.Equal(2, buffer.Count())
+
+	// Over capacity
+	_, err = buffer.Write([]byte{8, 9})
+	assert.Equal(ErrFull, err)
+	assert.Equal(2, buffer.Count())
+
+	// Read twice
+	n, err = buffer.Read(packet)
+	assert.NoError(err)
+	assert.Equal(2, n)
+	assert.Equal([]byte{2, 3}, packet[:n])
+	assert.Equal(1, buffer.Count())
+
+	n, err = buffer.Read(packet)
+	assert.NoError(err)
+	assert.Equal(2, n)
+	assert.Equal([]byte{6, 7}, packet[:n])
+	assert.Equal(0, buffer.Count())
+
+	// Nothing left.
+	err = buffer.Close()
+	assert.NoError(err)
+}
+
+func TestBufferLimitSize(t *testing.T) {
+	assert := assert.New(t)
+
+	buffer := NewBuffer()
+	buffer.SetLimitSize(5)
+
+	assert.Equal(0, buffer.Size())
+
+	// Write twice
+	n, err := buffer.Write([]byte{0, 1})
+	assert.NoError(err)
+	assert.Equal(2, n)
+	assert.Equal(2, buffer.Size())
+
+	n, err = buffer.Write([]byte{2, 3})
+	assert.NoError(err)
+	assert.Equal(2, n)
+	assert.Equal(4, buffer.Size())
+
+	// Over capacity
+	_, err = buffer.Write([]byte{4, 5})
+	assert.Equal(ErrFull, err)
+	assert.Equal(4, buffer.Size())
+
+	// Cheeky write at exact size.
+	n, err = buffer.Write([]byte{6})
+	assert.NoError(err)
+	assert.Equal(1, n)
+	assert.Equal(5, buffer.Size())
+
+	// Read once
+	packet := make([]byte, 4)
+	n, err = buffer.Read(packet)
+	assert.NoError(err)
+	assert.Equal(2, n)
+	assert.Equal([]byte{0, 1}, packet[:n])
+	assert.Equal(3, buffer.Size())
+
+	// Write once
+	n, err = buffer.Write([]byte{7, 8})
+	assert.NoError(err)
+	assert.Equal(2, n)
+	assert.Equal(5, buffer.Size())
+
+	// Over capacity
+	_, err = buffer.Write([]byte{9, 10})
+	assert.Equal(ErrFull, err)
+	assert.Equal(5, buffer.Size())
+
+	// Read everything
+	n, err = buffer.Read(packet)
+	assert.NoError(err)
+	assert.Equal(2, n)
+	assert.Equal([]byte{2, 3}, packet[:n])
+	assert.Equal(3, buffer.Size())
+
+	n, err = buffer.Read(packet)
+	assert.NoError(err)
+	assert.Equal(1, n)
+	assert.Equal([]byte{6}, packet[:n])
+	assert.Equal(2, buffer.Size())
+
+	n, err = buffer.Read(packet)
+	assert.NoError(err)
+	assert.Equal(2, n)
+	assert.Equal([]byte{7, 8}, packet[:n])
+	assert.Equal(0, buffer.Size())
+
+	// Nothing left.
+	err = buffer.Close()
+	assert.NoError(err)
+}
+
+func TestBufferMisc(t *testing.T) {
+	assert := assert.New(t)
+
+	buffer := NewBuffer()
+
+	// Write once
+	n, err := buffer.Write([]byte{0, 1, 2, 3})
+	assert.NoError(err)
+	assert.Equal(4, n)
+
+	// Try to read with a short buffer
+	packet := make([]byte, 3)
+	_, err = buffer.Read(packet)
+	assert.Equal(io.ErrShortBuffer, err)
+
+	// Try again with the right size
+	packet = make([]byte, 4)
+	n, err = buffer.Read(packet)
+	assert.NoError(err)
+	assert.Equal(4, n)
+
+	// Close
+	err = buffer.Close()
+	assert.NoError(err)
+
+	// Make sure you can Close twice
+	err = buffer.Close()
+	assert.NoError(err)
+}
+
+func benchmarkBuffer(b *testing.B, size int64) {
+	buffer := NewBuffer()
+	b.SetBytes(size)
+
+	done := make(chan struct{})
+	go func() {
+		packet := make([]byte, size)
+
+		for {
+			_, err := buffer.Read(packet)
+			if err == io.EOF {
+				break
+			} else if err != nil {
+				b.Error(err)
+				break
+			}
+		}
+
+		close(done)
+	}()
+
+	packet := make([]byte, size)
+
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		_, err := buffer.Write(packet)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+
+	err := buffer.Close()
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	<-done
+}
+
+func BenchmarkBuffer14(b *testing.B) {
+	benchmarkBuffer(b, 14)
+}
+
+func BenchmarkBuffer140(b *testing.B) {
+	benchmarkBuffer(b, 140)
+}
+
+func BenchmarkBuffer1400(b *testing.B) {
+	benchmarkBuffer(b, 1400)
+}


### PR DESCRIPTION
We're not able to use `bytes.Buffer` because it would combine multiple
Writes into a single Read. `packetio.Buffer` provides a similar but is
designed to work with packets, avoiding this situation.

There are similar buffers implemented separarely in webrtc/srtp/ice/mux.
These used channels and were too slow to keep up with the read loop. I
wrote a benchmark for comparison:

```
name                   old time/op    new time/op     delta
BenchmarkBuffer14-8       859ns ± 5%      129ns ± 4%   -84.93%
BenchmarkBuffer140-8      832ns ± 4%      154ns ± 4%   -81.43%
BenchmarkBuffer1400-8     825ns ± 8%      351ns ± 4%   -57.49%

name                   old speed      new speed       delta
BenchmarkBuffer14-8    16.3MB/s ± 5%  107.8MB/s ± 3%  +561.08%
BenchmarkBuffer140-8    168MB/s ± 4%    904MB/s ± 4%  +436.70%
BenchmarkBuffer1400-8  1.70GB/s ± 8%   3.99GB/s ± 4%  +134.74%
```

Note that this implementation has an unbounded buffer, while the channel
implementation has no buffer.